### PR TITLE
Fix chart.js package version 2.9.4

### DIFF
--- a/generators/app/templates/infrastructure/package.json
+++ b/generators/app/templates/infrastructure/package.json
@@ -32,7 +32,7 @@
     "apollo-upload-client": "^14.1.3",
     "attr-accept": "^2.2.2",
     "b64-to-blob": "^1.2.19",
-    "chart.js": "^2.9.4",
+    "chart.js": "2.9.4",
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",
     "eslint-plugin-react": "^7.22.0",


### PR DESCRIPTION
@Bit chart component is incompatible with the latest version of chart.js
 https://stackoverflow.com/questions/66959484/typeerror-cannot-read-property-defaults-of-undefined-when-using-the-react-wra