### PR TITLE
Replace const with functions in client.js 

### DIFF
--- a/generators/app/templates/infrastructure/src/apollo/AuthApolloProvider.js
+++ b/generators/app/templates/infrastructure/src/apollo/AuthApolloProvider.js
@@ -3,7 +3,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { AuthenticationContext } from '@axa-fr/react-oidc-context';
 
-import { client } from './client';
+import { getApolloClient } from './client';
 
 export function AuthApolloProvider({ children }) {
     const oidc = useContext(AuthenticationContext);
@@ -13,7 +13,7 @@ export function AuthApolloProvider({ children }) {
     }
 
     return (
-        <ApolloProvider client={client}>
+        <ApolloProvider client={getApolloClient()}>
             {children}
         </ApolloProvider>)
 }

--- a/generators/app/templates/infrastructure/src/assets/jss/components/menuStyle.js
+++ b/generators/app/templates/infrastructure/src/assets/jss/components/menuStyle.js
@@ -8,7 +8,6 @@ const sidebarStyle = theme => {
   const { defaultFont, menuActiveColor, menuActiveBkColor } = styles(theme);
 
   return {
-
     menuList: {
       marginTop: "15px",
       paddingLeft: "0",
@@ -40,7 +39,7 @@ const sidebarStyle = theme => {
       margin: "10px 15px 0",
       borderRadius: "3px",
       position: "relative",
-      display: "block",
+      display: "flex",
       padding: "10px 15px",
       backgroundColor: "transparent",
       ...defaultFont,

--- a/generators/app/templates/infrastructure/src/assets/jss/components/userMenuStyle.js
+++ b/generators/app/templates/infrastructure/src/assets/jss/components/userMenuStyle.js
@@ -107,7 +107,7 @@ const userMenuStyle = theme => {
       margin: '0px 15px',
       borderRadius: '3px',
       position: 'relative',
-      display: 'block',
+      display: 'flex',
       padding: '10px 15px',
       backgroundColor: 'transparent',
       ...defaultFont,


### PR DESCRIPTION
ApolloClient was initialized too early when first entering the application because the constants defined in client.js file were evaluated when DOM first rendered. Replacing them with function, will allow the creation of the ApolloClient instance when function are called, fixing multiple errors.