### PR TITLE
Fix app content background minHeight

### DIFF
--- a/generators/app/templates/infrastructure/src/assets/jss/components/appStyle.js
+++ b/generators/app/templates/infrastructure/src/assets/jss/components/appStyle.js
@@ -14,7 +14,7 @@ const appStyle = theme => {
       color: theme.palette.activeColor,
       position: "relative",
       top: "0",
-      height: "100vh",
+      minHeight: "100vh",
       "&:after": {
         display: "table",
         clear: "both",


### PR DESCRIPTION
The content background should not be limited with a fixed height value, we can define a minHeight instead.