### PR TITLE
Handle access_token destructuring error

### DIFF
--- a/generators/app/templates/infrastructure/src/apollo/client.js
+++ b/generators/app/templates/infrastructure/src/apollo/client.js
@@ -70,7 +70,7 @@ const httpLink = createUploadLink({
 
 const authLink = setContext(async (_, { headers }) => {
   const userManager = getUserManager();
-  const { access_token } = await userManager.getUser();
+  const { access_token } = await userManager.getUser() ?? emptyObject
   
   return {
     headers: {


### PR DESCRIPTION
When userManager.getUser() returns nothing, the access_token  destructuring throws an error