### PR TITLE
Fixed use of unimported "emptyObject" when not using subscription

### DIFF
--- a/generators/app/templates/infrastructure/src/apollo/client.js
+++ b/generators/app/templates/infrastructure/src/apollo/client.js
@@ -10,9 +10,9 @@ import { env } from "../utils/env"
 import { createUploadLink } from 'apollo-upload-client'
 import omitDeep from 'omit-deep-lodash'
 import { getUserManager } from "@axa-fr/react-oidc-core";
+import { emptyObject } from 'utils/constants'
 
 <%_ if (withSubscription) { _%>
-import { emptyObject } from 'utils/constants'
 // Create a WebSocket link:
 let wsLink
 const getWsLink = ()=> {  


### PR DESCRIPTION
"emptyObject" was imported only when using subscriptions, but it was used in the other case too, which generated compilation error. 