### PR TITLE
`@axa-fr/react-oidc` update to v6.x

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "javascript.format.enable": true,
   "typescript.format.enable": false,
   "cSpell.words": [
+    "Oidc",
     "totalsoft"
   ],
 }

--- a/generators/app/templates/infrastructure/package.json
+++ b/generators/app/templates/infrastructure/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "scripts": {
+    "prestart": "node setOidcDomains.js",
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test --env=jsdom",
@@ -22,7 +23,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.15",
-    "@axa-fr/react-oidc-context": "3.1.6",
+    "@axa-fr/react-oidc": "6.19.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.11.16",

--- a/generators/app/templates/infrastructure/public/OidcTrustedDomains.js
+++ b/generators/app/templates/infrastructure/public/OidcTrustedDomains.js
@@ -1,0 +1,46 @@
+// Copyright 2023 cdiaconita
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Add below trusted domains, access tokens will automatically injected to be send to
+// trusted domain can also be a path like https://www.myapi.com/users,
+// then all subroute like https://www.myapi.com/useers/1 will be authorized to send access_token to.
+
+// Service worker will continue to give access token to the JavaScript client
+// Ideal to hide refresh token from client JavaScript, but to retrieve access_token for some
+// scenarios which require it. For example, to send it via websocket connection.
+
+const REACT_APP_URL = `${oidc.REACT_APP_GQL_HTTP_PROTOCOL}://${oidc.REACT_APP_GQL}/graphql`
+
+// Domains used by OIDC server must be also declared here
+const defaultTrustedDomains = {
+    config_show_access_token: {
+      domains: [oidc.REACT_APP_IDENTITY_AUTHORITY, REACT_APP_URL],
+      showAccessToken: true
+    }
+  }
+  
+  const handler = {
+    get(target, name) {
+      if (name in target) {
+        return target[name]
+      }
+      return {
+        domains: [oidc.REACT_APP_IDENTITY_AUTHORITY, REACT_APP_URL],
+        showAccessToken: true
+      }
+    }
+  }
+  
+  const trustedDomains = new Proxy(defaultTrustedDomains, handler)
+  

--- a/generators/app/templates/infrastructure/setOidcDomains.js
+++ b/generators/app/templates/infrastructure/setOidcDomains.js
@@ -1,0 +1,51 @@
+// Copyright 2023 cdiaconita
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+const fs = require('fs')
+const dotenv = require('dotenv')
+
+const injectedObjectRegEx = /(const oidc = {[^}]*})/
+
+fs.readFile('public/OidcTrustedDomains.js', 'utf8', function (err, data) {
+  if (err) {
+    console.error(err)
+    return
+  }
+  const result = dotenv.config()
+  if (result.error) {
+    const path = `.env`
+    dotenv.config({ path })
+  }
+
+  const { REACT_APP_IDENTITY_AUTHORITY, REACT_APP_GQL_HTTP_PROTOCOL, REACT_APP_GQL } = process.env
+
+  const injectedValue =
+    'const oidc = ' +
+    JSON.stringify({
+      REACT_APP_IDENTITY_AUTHORITY,
+      REACT_APP_GQL_HTTP_PROTOCOL,
+      REACT_APP_GQL
+    })
+
+  if (data.match(injectedObjectRegEx)) {
+    data = data.replace(injectedObjectRegEx, injectedValue)
+  } else {
+    data = injectedValue + data
+  }
+
+  fs.writeFile('public/OidcTrustedDomains.js', data, 'utf8', function (err) {
+    if (err) throw err
+
+    console.log('The file was saved!')
+  })
+})

--- a/generators/app/templates/infrastructure/src/apollo/AuthApolloProvider.js
+++ b/generators/app/templates/infrastructure/src/apollo/AuthApolloProvider.js
@@ -11,7 +11,7 @@ export function AuthApolloProvider({ children }) {
   const { accessToken } = useOidcAccessToken(getOidcConfigName())
 
   useEffect(() => {
-    getAccessToken(accessToken)
+    setAccessToken(accessToken)
   }, [accessToken])
 
   if (oidcUserLoadingState === OidcUserStatus.Loading) {

--- a/generators/app/templates/infrastructure/src/apollo/AuthApolloProvider.js
+++ b/generators/app/templates/infrastructure/src/apollo/AuthApolloProvider.js
@@ -1,25 +1,28 @@
-import { ApolloProvider } from '@apollo/client';
-import React, { useContext } from 'react';
-import PropTypes from 'prop-types';
-import { AuthenticationContext } from '@axa-fr/react-oidc-context';
+import React, { useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { ApolloProvider } from '@apollo/client'
+import { useOidcUser, OidcUserStatus, useOidcAccessToken } from '@axa-fr/react-oidc'
 
-import { getApolloClient } from './client';
+import { getApolloClient, getAccessToken } from './client'
+import { getOidcConfigName } from "utils/functions"
 
 export function AuthApolloProvider({ children }) {
-    const oidc = useContext(AuthenticationContext);
+  const { oidcUserLoadingState } = useOidcUser(getOidcConfigName())
+  const { accessToken } = useOidcAccessToken(getOidcConfigName())
 
-    if (oidc.isLoading) {
-        return (<>auth loading</>)
-    }
+  useEffect(() => {
+    getAccessToken(accessToken)
+  }, [accessToken])
 
-    return (
-        <ApolloProvider client={getApolloClient()}>
-            {children}
-        </ApolloProvider>)
+  if (oidcUserLoadingState === OidcUserStatus.Loading) {
+    return <>auth loading</>
+  }
+
+  return <ApolloProvider client={getApolloClient()}>{children}</ApolloProvider>
 }
 
 AuthApolloProvider.propTypes = {
-    children: PropTypes.element.isRequired
+  children: PropTypes.element.isRequired
 }
 
-export default AuthApolloProvider;
+export default AuthApolloProvider

--- a/generators/app/templates/infrastructure/src/apollo/client.js
+++ b/generators/app/templates/infrastructure/src/apollo/client.js
@@ -73,15 +73,6 @@ const httpLink = createUploadLink({
   }),
 })
 
-const authLink = setContext(async (_, { headers }) => {
-  return {
-    headers: {
-      ...headers,
-      authorization: access_token ? `Bearer ${access_token}` : ''
-    }
-  }
-})
-
 const omitTypenameLink = new ApolloLink((operation, forward) => {
   if (operation.variables) {
     operation.variables = omitDeep(operation.variables, ['__typename'])
@@ -112,7 +103,7 @@ const retryLink = new RetryLink({
   }
 });
 
-const myAppLink = () => ApolloLink.from([omitTypenameLink, retryLink, authLink.concat(<% if (withSubscription) { %> link() <% } else { %> httpLink <%} %>)])
+const myAppLink = () => ApolloLink.from([omitTypenameLink, retryLink, <% if (withSubscription) { %> link() <% } else { %> httpLink <%} %>])
 
 const cache = new InMemoryCache({
   typePolicies: {

--- a/generators/app/templates/infrastructure/src/apollo/client.js
+++ b/generators/app/templates/infrastructure/src/apollo/client.js
@@ -10,33 +10,26 @@ import { setContext } from "@apollo/client/link/context"
 import { env } from "../utils/env"
 import { createUploadLink } from 'apollo-upload-client'
 import omitDeep from 'omit-deep-lodash'
-import { getUserManager } from "@axa-fr/react-oidc-core";
-import { emptyObject } from 'utils/constants'
 
 <%_ if (withSubscription) { _%>
 // Create a WebSocket link:
 let wsLink
-const getWsLink = ()=> {  
+const getWsLink = () => {  
   let activeSocket, currentAccessToken
   if (!wsLink) {
     const wsClient = createClient({
       url: `${env.REACT_APP_GQL_WS_PROTOCOL}://${env.REACT_APP_GQL}/graphql`,
       keepAlive: 10000, // ping server every 10 seconds,
       connectionParams: async () => {
-        const userManager = getUserManager()
-        const { access_token } = await userManager.getUser() ?? emptyObject
         currentAccessToken = access_token;
-
         return {
-          authorization: access_token ? `Bearer ${access_token}` : ""
+          authorization: access_token ? `Bearer ${access_token}` : ''
         }
       },
       on: {
         connected: socket => (activeSocket = socket),
         ping: async received => {
           if (!received) {
-            const userManager = getUserManager()
-            const { access_token } = (await userManager.getUser()) ?? emptyObject
             if (activeSocket.readyState === WebSocket.OPEN && currentAccessToken !== access_token) {
               setTimeout(() => {
                 activeSocket.close(1000, "Access token silent renew")
@@ -79,14 +72,11 @@ const httpLink = createUploadLink({
 })
 
 const authLink = setContext(async (_, { headers }) => {
-  const userManager = getUserManager();
-  const { access_token } = await userManager.getUser() ?? emptyObject
-  
   return {
     headers: {
       ...headers,
-      authorization: access_token ? `Bearer ${access_token}` : ""
-    },
+      authorization: access_token ? `Bearer ${access_token}` : ''
+    }
   }
 })
 
@@ -131,13 +121,18 @@ const cache = new InMemoryCache({
   }
 })
 
+let access_token
+export function getAccessToken(accessToken) {
+  access_token = accessToken
+}
+
 let apolloClient
 export const getApolloClient = () => {
   if (!apolloClient) {
     apolloClient = new ApolloClient({
       link: myAppLink(),
       cache
-    });
+    })
   }
   return apolloClient
 }

--- a/generators/app/templates/infrastructure/src/apollo/client.js
+++ b/generators/app/templates/infrastructure/src/apollo/client.js
@@ -11,6 +11,8 @@ import { env } from "../utils/env"
 import { createUploadLink } from 'apollo-upload-client'
 import omitDeep from 'omit-deep-lodash'
 
+let access_token
+
 <%_ if (withSubscription) { _%>
 // Create a WebSocket link:
 let wsLink
@@ -121,8 +123,7 @@ const cache = new InMemoryCache({
   }
 })
 
-let access_token
-export function getAccessToken(accessToken) {
+export function setAccessToken(accessToken) {
   access_token = accessToken
 }
 

--- a/generators/app/templates/infrastructure/src/components/menu/Menu.js
+++ b/generators/app/templates/infrastructure/src/components/menu/Menu.js
@@ -8,15 +8,17 @@ import { List } from './MenuStyle';
 <%_ if (withRights) { _%>
 import { isEmpty } from 'ramda';
 import { emptyArray } from 'utils/constants';
-import { useReactOidc } from '@axa-fr/react-oidc-context';
+import { useOidcUser } from '@axa-fr/react-oidc';
 import { useUserData } from 'hooks/rights';
-import { intersect } from 'utils/functions'; 
+import { intersect } from 'utils/functions';
+import { getOidcConfigName } from "utils/functions" 
 <%_ } _%>
 
 function Menu({ drawerOpen, withGradient }) {
   const location = useLocation();
   <%_ if (withRights){ _%>
-  const { oidcUser } = useReactOidc();
+  const { oidcUser } = useOidcUser(getOidcConfigName());
+
   const userRoles = oidcUser?.profile?.role || emptyArray;<%_ } _%>
 
   const activeRoute = useCallback(routeName => location.pathname.indexOf(routeName) > -1, [location.pathname]) 

--- a/generators/app/templates/infrastructure/src/components/menu/user/UserMenu.js
+++ b/generators/app/templates/infrastructure/src/components/menu/user/UserMenu.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback<% if (withMultiTenancy) { %>, useEffect, u
 import PropTypes from 'prop-types'
 import { useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { useReactOidc } from '@axa-fr/react-oidc-context'
+import { useOidcUser, useOidc } from '@axa-fr/react-oidc'
 
 import { Tooltip } from '@mui/material'
 import { PowerSettingsNew } from '@mui/icons-material'
@@ -25,7 +25,7 @@ import {
   StyledSelector
 } from './UserMenuStyle'
 import UserMenuItem from './UserMenuItem'
-
+import { getOidcConfigName } from "utils/functions"
 <%_ if (withMultiTenancy) { _%>
 import { useLazyQuery } from '@apollo/client';
 import { TenantContext } from 'providers/TenantAuthenticationProvider'
@@ -43,8 +43,9 @@ function UserMenu({ drawerOpen, avatar, language, changeLanguage, withGradient }
     const [openAvatar, setOpenAvatar] = useState(false);
     const { t } = useTranslation();
     const location = useLocation();
-    const { oidcUser, logout } = useReactOidc();
-
+    const { oidcUser } = useOidcUser(getOidcConfigName());
+    const { logout } = useOidc(getOidcConfigName());
+    
     <%_ if (withRights){ _%>
     const userRoles = oidcUser?.profile?.role || emptyArray;<%_ } _%>
   

--- a/generators/app/templates/infrastructure/src/components/routing/CustomRoute.js
+++ b/generators/app/templates/infrastructure/src/components/routing/CustomRoute.js
@@ -1,7 +1,8 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import { Container } from "./CustomRouteStyle";
-import { <% if (withRights) { %>useReactOidc, <% } %> withOidcSecure } from '@axa-fr/react-oidc-context';
+import {  getOidcConfigName } from "utils/functions";
+import { <% if (withRights) { %>useOidcUser, <% } %> withOidcSecure } from '@axa-fr/react-oidc';
 <%_ if (withRights) { _%>
 import { emptyArray } from "utils/constants";
 import { isEmpty } from "ramda";
@@ -9,11 +10,12 @@ import { useUserData } from "hooks/rights";
 import { FakeText, Forbidden } from '@totalsoft/rocket-ui';
 import { intersect } from "utils/functions";
 <% } %>
-function PrivateRoute({ component: Component, <% if (withRights) { %>roles, rights, <%}%> }) {
-    const SecuredComponent = useMemo(() => withOidcSecure(Component), [Component]);
+
+function PrivateRoute({ component: Component, <% if (withRights) { %>roles, rights, <%}%> }) { 
+    const SecuredComponent = useMemo(() => withOidcSecure(Component, undefined, undefined, getOidcConfigName()), [Component]);
 
     <%_ if (withRights) { _%>
-    const { oidcUser } = useReactOidc();
+    const { oidcUser } = useOidcUser(getOidcConfigName());
     const userRoles = oidcUser?.profile?.role || emptyArray;
     const { userData, loading } = useUserData();
     const userRights = userData?.rights || emptyArray

--- a/generators/app/templates/infrastructure/src/hooks/rights.js
+++ b/generators/app/templates/infrastructure/src/hooks/rights.js
@@ -1,8 +1,9 @@
 import permissions from 'constants/permissions'
 import { gql } from '@apollo/client'
 import { useQueryWithErrorHandling } from './errorHandling'
-import { useReactOidc } from '@axa-fr/react-oidc-context';
+import { useOidcUser } from '@axa-fr/react-oidc'
 import { includes } from 'ramda';
+import { getOidcConfigName } from "utils/functions";
 
 const { viewSettings} = permissions
 const GET_USER_DATA = gql`
@@ -16,7 +17,8 @@ const GET_USER_DATA = gql`
 `
 
 export function useUserData() {
-    const { oidcUser } = useReactOidc();
+    const { oidcUser } = useOidcUser(getOidcConfigName());
+
     const externalUserId = oidcUser?.profile?.sub;
 
     const { data, ...res } = useQueryWithErrorHandling(GET_USER_DATA, {
@@ -29,7 +31,8 @@ export function useUserData() {
 }
 
 export const useRights = () => {
-    const { oidcUser } = useReactOidc();
+    const { oidcUser } = useOidcUser(getOidcConfigName());
+
     const externalUserId = oidcUser?.profile?.sub;
 
     const { data } = useQueryWithErrorHandling(GET_USER_DATA, {

--- a/generators/app/templates/infrastructure/src/providers/AuthenticationProvider.js
+++ b/generators/app/templates/infrastructure/src/providers/AuthenticationProvider.js
@@ -1,58 +1,34 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import getAuthenticationConfiguration from 'utils/auth/authConfig'
-import { AuthenticationProvider as DefaultProvider, getUserManager, oidcLog, useReactOidc } from '@axa-fr/react-oidc-context'
+import { OidcProvider } from '@axa-fr/react-oidc'
 import { Authenticating } from 'components/login/Authenticating'
 import { CallbackPage } from 'components/login/CallbackPage'
 import { NotAuthenticated } from 'components/login/NotAuthenticated'
 import { SessionExpired } from 'components/login/SessionExpired'
 import { Forbidden } from '@totalsoft/rocket-ui'
+import { getOidcConfigName } from "utils/functions"
 
 const AuthenticationProvider = props => {
   const { children } = props
   const configuration = getAuthenticationConfiguration()
+  const configName = getOidcConfigName()
 
   return (
-    <DefaultProvider
+    <OidcProvider
       configuration={configuration}
-      loggerLevel={oidcLog.DEBUG}
-      isEnabled={true}
-      authenticating={Authenticating}
-      callbackComponentOverride={CallbackPage}
-      notAuthenticated={NotAuthenticated}
+      configurationName={configName}
+      authenticatingComponent={Authenticating}
+      callbackSuccessComponent={CallbackPage}
+      loadingComponent={NotAuthenticated}
       sessionLostComponent={SessionExpired}
-      notAuthorized={Forbidden}
+      authenticatingErrorComponent={Forbidden}
     >
-      <Reader>{children}</Reader>
-    </DefaultProvider>
+      {children}
+    </OidcProvider>
   )
 }
 
 AuthenticationProvider.propTypes = { children: PropTypes.element.isRequired }
-
-const userSignedOut = async () => {
-  const userManager = getUserManager()
-  await userManager.removeUser()
-  await userManager.signinRedirect()
-}
-
-const Reader = props => {
-  const { children } = props
-  const { events } = useReactOidc()
-
-  useEffect(() => {
-    if (!events) {
-      return
-    }
-
-    events.addUserSignedOut(userSignedOut)
-    return () => {
-      events.removeUserSignedOut(userSignedOut)
-    }
-  }, [events])
-
-  return children
-}
-Reader.propTypes = { children: PropTypes.element.isRequired }
 
 export default AuthenticationProvider

--- a/generators/app/templates/infrastructure/src/providers/TenantAuthenticationProvider.js
+++ b/generators/app/templates/infrastructure/src/providers/TenantAuthenticationProvider.js
@@ -32,7 +32,7 @@ const TenantAuthenticationProvider = props => {
     <TenantContext.Provider value={setTenantCallback}>
       <OidcProvider
         configuration={configuration}
-        configurationName={tenant || getOidcConfigName()}
+        configurationName={getOidcConfigName()}
         authenticatingComponent={Authenticating}
         callbackSuccessComponent={CallbackPage}
         loadingComponent={NotAuthenticated}

--- a/generators/app/templates/infrastructure/src/providers/TenantAuthenticationProvider.js
+++ b/generators/app/templates/infrastructure/src/providers/TenantAuthenticationProvider.js
@@ -1,81 +1,50 @@
-import React, { createContext, useContext, useEffect, useCallback } from "react"
-import PropTypes from "prop-types"
-import getAuthenticationConfiguration from 'utils/auth/authConfig';
-import { AuthenticationProvider, oidcLog, useReactOidc, getUserManager } from '@axa-fr/react-oidc-context';
-import { setUserManager } from "@axa-fr/react-oidc-core/dist/services/authenticationService"
-import { Authenticating } from "components/login/Authenticating";
-import { CallbackPage } from "components/login/CallbackPage";
-import { NotAuthenticated } from "components/login/NotAuthenticated";
-import { SessionExpired } from "components/login/SessionExpired";
-import { Forbidden } from '@totalsoft/rocket-ui';
-import { useSessionStorage } from "hooks/sessionStorage";
+import React, { createContext, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import getAuthenticationConfiguration from 'utils/auth/authConfig'
+import { Authenticating } from 'components/login/Authenticating'
+import { CallbackPage } from 'components/login/CallbackPage'
+import { NotAuthenticated } from 'components/login/NotAuthenticated'
+import { SessionExpired } from 'components/login/SessionExpired'
+import { Forbidden } from '@totalsoft/rocket-ui'
+import { useSessionStorage } from 'hooks/sessionStorage'
+import { OidcProvider } from '@axa-fr/react-oidc'
+import { getOidcConfigName } from "utils/functions"
 
 export const TenantContext = createContext()
 const TenantAuthenticationProvider = props => {
-    const { children } = props
-    const [tenant, setTenant] = useSessionStorage("tid")
+  const { children } = props
+  const [tenant, setTenant] = useSessionStorage('tenant')
 
-    const setTenantCallback = useCallback(async (e) => {
-        if ((!e && !tenant) ||
-            (`${e}`.toUpperCase() === `${tenant}`.toUpperCase())) {
-            return
-        }
+  const setTenantCallback = useCallback(
+    async e => {
+      if ((!e && !tenant) || `${e}`.toUpperCase() === `${tenant}`.toUpperCase()) {
+        return
+      }
 
-        const userManager = getUserManager()
-        await userManager.removeUser()
+      setTenant(e)
+    },
+    [setTenant, tenant]
+  )
 
-        setUserManager(null)
-        setTenant(e)
-    }, [setTenant, tenant])
+  const configuration = getAuthenticationConfiguration(tenant)
 
-    const configuration = getAuthenticationConfiguration(tenant)
-
-    return <TenantContext.Provider value={setTenantCallback}>
-        <AuthenticationProvider
-            configuration={configuration}
-            loggerLevel={oidcLog.INFO}
-            isEnabled={true}
-            authenticating={Authenticating}
-            callbackComponentOverride={CallbackPage}
-            notAuthenticated={NotAuthenticated}
-            sessionLostComponent={SessionExpired}
-            notAuthorized={Forbidden}
-        >
-            <TenantReader>
-                {children}
-            </TenantReader>
-        </AuthenticationProvider>
+  return (
+    <TenantContext.Provider value={setTenantCallback}>
+      <OidcProvider
+        configuration={configuration}
+        configurationName={tenant || getOidcConfigName()}
+        authenticatingComponent={Authenticating}
+        callbackSuccessComponent={CallbackPage}
+        loadingComponent={NotAuthenticated}
+        sessionLostComponent={SessionExpired}
+        authenticatingErrorComponent={Forbidden}
+      >
+        {children}
+      </OidcProvider>
     </TenantContext.Provider>
+  )
 }
 
 TenantAuthenticationProvider.propTypes = { children: PropTypes.element.isRequired }
-
-const userSignedOut = callback => async () => {
-    const userManager = getUserManager()
-    await userManager.removeUser()
-    callback()
-}
-
-const TenantReader = props => {
-    const { children } = props
-
-    const setTenant = useContext(TenantContext)
-    const { events } = useReactOidc();
-
-    useEffect(() => {
-        if (!events) {
-            return
-        }
-
-        const onUserSignedOut = userSignedOut(setTenant)
-        events.addUserSignedOut(onUserSignedOut);
-        return () => {
-            events.removeUserSignedOut(onUserSignedOut);
-        };
-    }, [events, setTenant])
-
-    return children
-}
-TenantReader.propTypes = { children: PropTypes.element.isRequired }
 
 export default TenantAuthenticationProvider

--- a/generators/app/templates/infrastructure/src/utils/auth/authConfig.js
+++ b/generators/app/templates/infrastructure/src/utils/auth/authConfig.js
@@ -1,9 +1,10 @@
+import { TokenRenewMode } from '@axa-fr/react-oidc'
 import { env } from "utils/env";
 <%_ if (withMultiTenancy) { _%>
 import { isNullOrWhitespace } from '../functions';
 <%_}_%>
 
-const root = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}`
+export const root = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}`
 const AUTH = {
     CALLBACK: '/authentication/callback',
     SILENT_CALLBACK: '/authentication/silent_callback'
@@ -20,14 +21,9 @@ const getAuthenticationConfiguration = (<% if (withMultiTenancy) { %>tenant<%}%>
         authority: env.REACT_APP_IDENTITY_AUTHORITY,
         redirect_uri: `${root}${AUTH.CALLBACK}`,
         silent_redirect_uri: `${root}${AUTH.SILENT_CALLBACK}`,
-        response_type: 'code',
         scope: 'openid profile ' + env.REACT_APP_IDENTITY_SCOPE,
+        token_renew_mode: TokenRenewMode.access_token_invalid,
         post_logout_redirect_uri: `${root}`,
-        automaticSilentRenew: true,
-        loadUserInfo: true,
-        triggerAuthFlow: true,
-        revokeAccessTokenOnSignout: true,
-        register_uri: `${env.REACT_APP_IDENTITY_AUTHORITY}/${env.REACT_APP_REGISTER_REDIRECT_URL}?returnUrl=${root}/register&clientId=${env.REACT_APP_IDENTITY_CLIENT_ID}`,
         acr_values,
     }
 }

--- a/generators/app/templates/infrastructure/src/utils/functions.js
+++ b/generators/app/templates/infrastructure/src/utils/functions.js
@@ -49,3 +49,8 @@ export const addMilliseconds = curry((milliseconds, date) => new Date(date.getTi
 
 // subtractOneMillisecond :: Date -> Date
 export const subtractOneMillisecond = addMilliseconds(-1)
+
+export const getOidcConfigName = () => {
+    const tid = <% if (withMultiTenancy){ _%> sessionStorage.getItem("tenant") || <%_ } _%> 'config_show_access_token';
+    return tid
+}

--- a/generators/app/templates/infrastructure/src/utils/i18n.js
+++ b/generators/app/templates/infrastructure/src/utils/i18n.js
@@ -74,7 +74,7 @@ i18n
       },
 
       react: {
-        wait: true,
+        useSuspense: true,
         usePureComponent: true
       },
 


### PR DESCRIPTION
We updated `@axa-fr/react-oidc` library which came with the following changes:

- For HTTP calls, a ServiceWorker is used to automatically inject the token.
- We still inject the token manually for WS calls.
- When we use one of the hooks exported by the library, we have to provide a name to load the configuration. We created the function `getOidcConfigName`  which will provide a default configuration name (`config_show_access_token`) or in case the project is multitenancy it will provide a tenant specific configuration name (tenant id or the default name).
- Two files were added inside the `public` folder:
   1. `OidcServiceWorker.js` which is generated when running `npm install`
   2. `OidcTrustedDomains.js` which contains the trusted domains configuration for ServiceWorker in order to inject the token and the flag for accessing the token for WS calls (`showAccessToken`)
 - `OidcTrustedDomains.js` is going to be modified at runtime by the `setOidcDomains.js` script file that is going to populate the file with the necessary environment variables and for production we added a new script in `setenv.js` file.