### PR TITLE
remove defaultPropTypes and lodash.curry

### DIFF
--- a/generators/app/templates/infrastructure/package.json
+++ b/generators/app/templates/infrastructure/package.json
@@ -43,7 +43,6 @@
     "i18next": "^22.5.1",
     "i18next-browser-languagedetector": "^7.0.2",
     "i18next-http-backend": "^2.2.1",
-    "lodash.curry": "^4.1.1",
     "moment": "2.29.4",
     "oidc-client": "^1.11.5",
     "omit-deep-lodash": "^1.1.7",

--- a/generators/app/templates/infrastructure/src/components/routing/CustomRoute.js
+++ b/generators/app/templates/infrastructure/src/components/routing/CustomRoute.js
@@ -5,20 +5,20 @@ import {  getOidcConfigName } from "utils/functions";
 import { <% if (withRights) { %>useOidcUser, <% } %> withOidcSecure } from '@axa-fr/react-oidc';
 <%_ if (withRights) { _%>
 import { emptyArray } from "utils/constants";
-import { isEmpty } from "ramda";
+import { isEmpty, defaultTo } from "ramda";
 import { useUserData } from "hooks/rights";
 import { FakeText, Forbidden } from '@totalsoft/rocket-ui';
 import { intersect } from "utils/functions";
 <% } %>
 
-function PrivateRoute({ component: Component, <% if (withRights) { %>roles, rights, <%}%> }) { 
+function PrivateRoute({ component: Component, <% if (withRights) { %>roles = emptyArray, rights = emptyArray <%}%> }) { 
     const SecuredComponent = useMemo(() => withOidcSecure(Component, undefined, undefined, getOidcConfigName()), [Component]);
 
     <%_ if (withRights) { _%>
     const { oidcUser } = useOidcUser(getOidcConfigName());
-    const userRoles = oidcUser?.profile?.role || emptyArray;
+    const userRoles = defaultTo(emptyArray, userData?.roles)
     const { userData, loading } = useUserData();
-    const userRights = userData?.rights || emptyArray
+    const userRights = defaultTo(emptyArray, userData?.rights)
 
     let allow = false
     if (isEmpty(rights) && isEmpty(roles) && oidcUser) {
@@ -42,13 +42,6 @@ function PrivateRoute({ component: Component, <% if (withRights) { %>roles, righ
     <%_ } _%>
 }
 
-<%_ if (withRights) { _%>
-PrivateRoute.defaultProps = {
-    roles: emptyArray,
-    rights: emptyArray
-};
-<%_ } _%>
-
 PrivateRoute.propTypes = {
     component: PropTypes.func<% if (withRights) { %>,
     roles: PropTypes.array,
@@ -56,25 +49,12 @@ PrivateRoute.propTypes = {
     <%_ } _%>
 };
 
-function CustomRoute({ isPrivate, component: Component, ...props }) {
+function CustomRoute({ isPrivate = true, component: Component, fullWidth= false, ...props }) {
     return <Container>{isPrivate ? <PrivateRoute component={Component} {...props} /> : <Component />}</Container>
   }
 
-CustomRoute.defaultProps = {
-  <% if (withRights) { %>
-  roles: emptyArray,
-  rights: emptyArray,
-  <%_ } _%>
-  isPrivate: true,
-  fullWidth: false
-}
-
 CustomRoute.propTypes = {
   component: PropTypes.func,
-  <% if (withRights) { %>
-  roles: PropTypes.array,
-  rights: PropTypes.array,
-  <%_ } _%>
   isPrivate: PropTypes.bool,
   fullWidth: PropTypes.bool
 }

--- a/generators/app/templates/infrastructure/src/utils/propertyChangeAdapters/index.js
+++ b/generators/app/templates/infrastructure/src/utils/propertyChangeAdapters/index.js
@@ -1,4 +1,4 @@
-import curry from 'lodash.curry';
+import { curry } from 'ramda'
 
 export const addPropertyPrefix = curry((prefix, fn, prop) => fn(`${prefix}.${prop}`))
 


### PR DESCRIPTION
Remove `defaultPropTypes` because it is no longer the recommended way for default properties.
Remove `lodash.curry` and use `curry` from ramda.