### PR TITLE
upgrade react-router to v7

### DIFF
--- a/generators/app/templates/infrastructure/package.json
+++ b/generators/app/templates/infrastructure/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^18.3.1",
     "react-i18next": "^15.1.1",
     "react-responsive": "^10.0.0",
-    "react-router-dom": "^6.28.0",
+    "react-router": "^7.0.1",
     "react-scripts": "^5.0.1",
     "react-super-responsive-table": "^6.0.0",
     "simplebar-react": "^3.2.6",

--- a/generators/app/templates/infrastructure/src/components/App.js
+++ b/generators/app/templates/infrastructure/src/components/App.js
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, Suspense } from 'react'
-import { Outlet, useLocation } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { getTheme, ToastContainer } from '@totalsoft/rocket-ui'
 

--- a/generators/app/templates/infrastructure/src/components/FormPrompt.js
+++ b/generators/app/templates/infrastructure/src/components/FormPrompt.js
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
-import { useBlocker } from 'react-router-dom'
+import { useBlocker } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { equals } from 'ramda'
 

--- a/generators/app/templates/infrastructure/src/components/layout/header/Header.js
+++ b/generators/app/templates/infrastructure/src/components/layout/header/Header.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import { reduce } from 'ramda'
 import menuConfig from 'constants/menuConfig'
 import { emptyArray, mobileWidth } from 'utils/constants'

--- a/generators/app/templates/infrastructure/src/components/menu/Menu.js
+++ b/generators/app/templates/infrastructure/src/components/menu/Menu.js
@@ -1,6 +1,6 @@
 import { useCallback<%_ if (withRights){ _%>, useMemo <%_ } _%>} from 'react'
 import PropTypes from 'prop-types'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import MenuItem from './MenuItem'
 import CollapsibleMenuItem from './CollapsibleMenuItem'
 import { StyledList } from './MenuStyle'

--- a/generators/app/templates/infrastructure/src/components/menu/MenuStyle.js
+++ b/generators/app/templates/infrastructure/src/components/menu/MenuStyle.js
@@ -1,6 +1,6 @@
 import { styled, List as MuiList, ListItemIcon as MuiListItemIcon, ListItemText as MuiListItemText } from '@mui/material'
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material'
-import { NavLink } from 'react-router-dom'
+import { NavLink } from 'react-router'
 import { includes } from 'ramda'
 import styles from 'assets/jss/styles'
 

--- a/generators/app/templates/infrastructure/src/components/menu/user/UserMenu.js
+++ b/generators/app/templates/infrastructure/src/components/menu/user/UserMenu.js
@@ -1,6 +1,6 @@
 import { useState, useCallback<% if (withMultiTenancy) { %>, useEffect, useContext<% } %><% if (withRights) { %>, useMemo <% } %>} from 'react'
 import PropTypes from 'prop-types'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { useOidcUser, useOidc } from '@axa-fr/react-oidc'
 import { Collapse, Tooltip } from '@mui/material'

--- a/generators/app/templates/infrastructure/src/routes/config.js
+++ b/generators/app/templates/infrastructure/src/routes/config.js
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom'
+import { Navigate } from 'react-router'
 import CustomRoute from 'components/routing/CustomRoute'
 
 import { Forbidden, NotFound } from '@totalsoft/rocket-ui'

--- a/generators/app/templates/infrastructure/src/routes/root.js
+++ b/generators/app/templates/infrastructure/src/routes/root.js
@@ -1,24 +1,10 @@
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter } from 'react-router'
+import { RouterProvider } from 'react-router/dom'
 import App from 'components/App'
 import routes from './config'
 
 export default function Root() {
-  const router = createBrowserRouter([{ element: <App />, children: routes }], {
-    future: {
-      v7_relativeSplatPath: true,
-      v7_fetcherPersist: true,
-      v7_normalizeFormMethod: true,
-      v7_partialHydration: true,
-      v7_skipActionErrorRevalidation: true
-    }
-  })
+  const router = createBrowserRouter([{ element: <App />, children: routes }])
 
-  return (
-    <RouterProvider
-      router={router}
-      future={{
-        v7_startTransition: true
-      }}
-    />
-  )
+  return <RouterProvider router={router} />
 }


### PR DESCRIPTION
Upgraded react-router package to v7> This upgrade includes the following:
- removed `react-router-dom` package. It has been replaced by `react-router` package:
```
npm uninstall react-router-dom
npm install react-router@latest
```
- all imports have been update to `react-router`:
```
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
```
- `RouterProvider` and `HydratedRouter` come from a deep import because they depend on "react-dom":
```
-import { RouterProvider } from "react-router-dom";
+import { RouterProvider } from "react-router/dom";
```
Instead of manually updating imports, you can use this command. Make sure your git working tree is clean though so you can revert if it doesn't work as expected:
```
find ./path/to/src \( -name "*.tsx" -o -name "*.ts" -o -name "*.js" -o -name "*.jsx" \) -type f -exec sed -i '' 's|from "react-router-dom"|from "react-router"|g' {} +
```

For more information about changes from v6 to v7, visit the official [upgrade documentation](https://reactrouter.com/upgrading/v6)
